### PR TITLE
Solving mtf.random distribution

### DIFF
--- a/examples/mtf_random.py
+++ b/examples/mtf_random.py
@@ -1,0 +1,59 @@
+from mpi4py import MPI
+import time
+import os
+# Pin only one GPU per horovod process
+comm = MPI.COMM_WORLD
+#os.environ["CUDA_VISIBLE_DEVICES"]="%d"%(comm.rank+1) # This is specific to my machine
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
+import mesh_tensorflow as mtf
+from mesh_tensorflow.hvd_simd_mesh_impl import HvdSimdMeshImpl
+
+
+# IDRIS allocation
+"""
+4 GPUs
+salloc --nodes=1 --ntasks-per-node=4 --cpus-per-task=10 --gres=gpu:4 --hint=nomultithread -A ftb@gpu --reservation=hackathon_idr25
+module load tensorflow-gpu/py3/2.4.1+nccl-2.8.3-1
+srun --unbuffered --mpi=pmi2 /gpfslocalsup/pub/idrtools/bind_gpu.sh python -u mtf_random.py
+"""
+
+# Define the input seed
+input_seed = 0
+
+# We create a small mesh
+graph = mtf.Graph()
+mesh = mtf.Mesh(graph, "my_mesh")
+batch_dim = mtf.Dimension("batch", 2)
+nx_dim = mtf.Dimension('nx_block', 4)
+ny_dim = mtf.Dimension('ny_block', 4)
+# Defines the mesh structure
+mesh_shape = [ ("row", 2), ("col", 2)]
+# layout_rules = [('batch', 'row'),  ("nx_block","col")]
+layout_rules = [('batch', 'row')]
+
+# mesh_shape = [ ("row", 2)]
+# layout_rules = [('batch', 'row')]
+
+
+kwargs={'maxval':1, 'seed':input_seed}
+# data_same = mtf.random_uniform(mesh, [ny_dim], **kwargs)
+data = mtf.random_uniform(mesh, [batch_dim, nx_dim, ny_dim], **kwargs)
+
+mesh_impl = HvdSimdMeshImpl(mtf.convert_to_shape(mesh_shape), 
+                            mtf.convert_to_layout_rules(layout_rules))
+
+lowering = mtf.Lowering(graph, {mesh:mesh_impl})
+
+res = lowering.export_to_tf_tensor(data)
+# res_same = lowering.export_to_tf_tensor(data_same)
+
+# Execute and retrieve result
+with tf.Session() as sess:
+    r = sess.run(res)
+    # r_same = sess.run(res_same)
+
+print("Final shape", r.shape)
+print("Final result", r)
+# print("Final result_same", r_same)
+

--- a/mesh_tensorflow/hvd_simd_mesh_impl.py
+++ b/mesh_tensorflow/hvd_simd_mesh_impl.py
@@ -21,8 +21,10 @@ from __future__ import print_function
 
 import math
 import os
+import random
 import collections
 import numpy as np
+
 from mesh_tensorflow import ops_with_redefined_builtins as mtf
 from mesh_tensorflow import utils
 from six.moves import xrange  # pylint: disable=redefined-builtin
@@ -539,24 +541,26 @@ class HvdSimdMeshImpl(mtf.MeshImpl):
     print("HEEELLOO")
     return self.LaidOutTensor([t])
 
+  def slice_begin(self, tensor_shape):
+    """Variant of slice begin for SIMD"""
+    tensor_layout = self.tensor_layout(tensor_shape)
+    slice_shape = self.slice_shape(tensor_shape)
+
+    slice_begins = [
+      0 if mesh_axis is None else hvd.rank(communicator_id=self._comms_id[self.shape[mesh_axis].name])*slice_shape[i]
+      for i,mesh_axis in enumerate(tensor_layout)
+      ]
+    return slice_begins
+
   def slice(self, tf_tensor, tensor_shape):
     """"Slice out the corresponding part of tensor."""
     tensor_layout = self.tensor_layout(tensor_shape)
-    print(tensor_layout)
     if tensor_layout.is_fully_replicated:
       return self.LaidOutTensor([tf_tensor])
     else:
       slice_shape = self.slice_shape(tensor_shape)
-      print(slice_shape)
-      slice_begins = [
-          0 if mesh_axis is None else hvd.rank(communicator_id=self._comms_id[self.shape[mesh_axis].name])*slice_shape[i]
-          for i,mesh_axis in enumerate(tensor_layout)
-          ]
-      print(slice_begins)
+      slice_begins = self.slice_begin(tensor_shape)
       slice_begins_tensor = tf.stack(slice_begins)
-      # # slice on source device
-      # selected_slice_begin = tf.gather(slice_begins_tensor, self.pnum_tensor)
-      # print(selected_slice_begin, slice_shape, self.pnum_tensor )
       return self.LaidOutTensor(
           [tf.slice(tf_tensor, slice_begins_tensor, slice_shape)])
 

--- a/mesh_tensorflow/hvd_simd_mesh_impl.py
+++ b/mesh_tensorflow/hvd_simd_mesh_impl.py
@@ -316,7 +316,7 @@ class HvdSimdMeshImpl(mtf.MeshImpl):
       x: a LaidOutTensor
       mesh_axis: an integer - the mesh axis along which to group
       concat_axis: an integer (the Tensor axis along which to concatenate)
-      stack: a boolean - whether to atack instead of concat
+      stack: a boolean - whether to stack instead of concat
     Returns:
       a LaidOutTensor
     """

--- a/mesh_tensorflow/hvd_simd_mesh_impl.py
+++ b/mesh_tensorflow/hvd_simd_mesh_impl.py
@@ -562,8 +562,11 @@ class HvdSimdMeshImpl(mtf.MeshImpl):
       return self.LaidOutTensor([tf_tensor])
     else:
       slice_shape = self.slice_shape(tensor_shape)
+    
       
       slice_begins = self.slice_begin(tensor_shape)
+      
+      print('slice_begins: ', slice_begins)
       slice_begins_tensor = tf.stack(slice_begins)
 
       return self.LaidOutTensor(
@@ -595,39 +598,46 @@ class HvdSimdMeshImpl(mtf.MeshImpl):
     Args:
       shape: a Shape
       tf_fn: a function such as tf.random.uniform
-      kwargs: kwargs to pass to tf_fn, including the seed
+      kwargs: kwargs to pass to tf_fn, including or not the seed
 
     Returns:
       a LaidOutTensor
-    """
-    """
-    # Old implementation
-    slice_shape = self.slice_shape(shape)
-
-    x = tf_fn(slice_shape, **kwargs)
-    # TPU does not have seeds enabled.  Sync up the
-    # random choices by zeroing out all but the first core per group of
-    # identical slices, then allreducing by group.
-    layout = self.tensor_layout(shape)
-    # we need to sync across these axes.
-    mesh_axes = [i for i in xrange(self.ndims)
-                 if i not in layout.tensor_axis_to_mesh_axis]
-    multiplier = 1.0
-    for axis in mesh_axes:
-      multiplier *= tf.cast(
-          tf.equal(self.laid_out_pcoord(axis).one_slice, 0), x.dtype)
-    x *= multiplier
-    x = self.LaidOutTensor([x])
-    x = self.allreduce(x, mesh_axes, "SUM")
-    return x
     """
     # Tobi-doc
     # kwargs['seed'] is the original seed.
     # If we don't distribute we use that same seed for all the random variables
     # If we distribute a big tensor we need to change the seed.
-    # Dependign on the mesh, the tensor dimensions, and how we are distribting them we need to generate a set of seeds for each
+    # Depending on the mesh, the tensor dimensions, and how we are distribting them we need to generate a set of seeds for each
     # GPU. These seeds might need to be identical or different as a function of the distribution strategy.
+   
+    slice_shape = self.slice_shape(shape)
+
+    # Get the common seed to all processes
+    if 'seed' in kwargs:
+        # Use the defined input seed if specified
+        op_seed = kwargs.pop('seed')
+    else:
+        # Generate a random seed and broadcast it among all the processes with the MPI communicaiton
+        op_seed = random.random()
+        # WARNING! Using MPI world communicator. All processes should be involved in this operation.
+        op_seed = self._comms['world'].bcast(op_seed, root=0)
     
+    # Create process-specific seed shifts
+    max_dim = np.max(slice_shape)
+    my_slice_begins = self.slice_begin(shape)
+    seed = np.sum([0 if dim_id==0 else it*max_dim+dim_id  for it, dim_id in enumerate(my_slice_begins)])
+
+    # Join the common seed and process-specific seed shifts
+    seed += op_seed
+
+    # seeds are necessary to make sure that slices that should have the
+    # same values actually do have the same values.
+    # Alternative implementation -> Needs to have a fixed hash function across different processes
+    # seed = hash("%s,%s" % (op_seed, self.slice_begin(shape)))
+    
+    return self.LaidOutTensor([tf_fn(slice_shape, seed=seed, **kwargs)])
+
+    """
     slice_shape = self.slice_shape(shape)
     # Get the biggest dimension to be sure that the seeds are different when they are supposed to be different.
     max_dim = np.max(slice_shape)
@@ -662,7 +672,7 @@ class HvdSimdMeshImpl(mtf.MeshImpl):
  
         x = tf_fn(slice_shape, **kwargs)
         return self.LaidOutTensor([x])
-    
+    """
 
   def export_to_tf_tensor(self, x, laid_out_x):
     """Turn a Tensor into a tf.Tensor.

--- a/mesh_tensorflow/hvd_simd_mesh_impl.py
+++ b/mesh_tensorflow/hvd_simd_mesh_impl.py
@@ -324,7 +324,9 @@ class HvdSimdMeshImpl(mtf.MeshImpl):
     num_parts = self.shape[mesh_axis].size
     name_dim  = self.shape[mesh_axis].name
 
-    print('CONCAT', stack)
+    # TODO [TL]
+    # print('inside allconcat, CONCAT', stack)
+    # print('hvd.rank(): ',hvd.rank(), ', old_shape: ', old_shape, ', num_parts: ', num_parts, ', name_dim: ', name_dim)
 
     # Moving axis to concatenate at the top
     perm = [concat_axis] + [i for i in range(len(old_shape)) if i not in [concat_axis]]
@@ -542,18 +544,21 @@ class HvdSimdMeshImpl(mtf.MeshImpl):
   def slice(self, tf_tensor, tensor_shape):
     """"Slice out the corresponding part of tensor."""
     tensor_layout = self.tensor_layout(tensor_shape)
-    print(tensor_layout)
+    # print('tensor_layout: ', tensor_layout)
     if tensor_layout.is_fully_replicated:
       return self.LaidOutTensor([tf_tensor])
     else:
       slice_shape = self.slice_shape(tensor_shape)
-      print(slice_shape)
+      # print('slice_shape: ', slice_shape)
       slice_begins = [
           0 if mesh_axis is None else hvd.rank(communicator_id=self._comms_id[self.shape[mesh_axis].name])*slice_shape[i]
           for i,mesh_axis in enumerate(tensor_layout)
           ]
-      print(slice_begins)
+      
+      print('hvd.rank(): ', hvd.rank(), ', tf.shape(tf_tensor): ', tf.shape(tf_tensor), ', slice_begins: ', slice_begins, ', slice_shape: ', slice_shape)
+      
       slice_begins_tensor = tf.stack(slice_begins)
+      # print('slice_begins_tensor: ', slice_begins_tensor)
       # # slice on source device
       # selected_slice_begin = tf.gather(slice_begins_tensor, self.pnum_tensor)
       # print(selected_slice_begin, slice_shape, self.pnum_tensor )

--- a/mesh_tensorflow/hvd_simd_mesh_impl.py
+++ b/mesh_tensorflow/hvd_simd_mesh_impl.py
@@ -593,6 +593,7 @@ class HvdSimdMeshImpl(mtf.MeshImpl):
     """
     # TODO(noam): can we make things better with stateless_random?
     slice_shape = self.slice_shape(shape)
+    """
     x = tf_fn(slice_shape, **kwargs)
     # TPU does not have seeds enabled.  Sync up the
     # random choices by zeroing out all but the first core per group of
@@ -609,6 +610,17 @@ class HvdSimdMeshImpl(mtf.MeshImpl):
     x = self.LaidOutTensor([x])
     x = self.allreduce(x, mesh_axes, "SUM")
     return x
+    """
+    # spit the seed along the slices
+    slice_shape = self.slice_shape(shape)
+    if 'seed' in kwargs.keys():
+      kwargs['seed'] += hvd.rank()
+
+    #if hvd.rank()==0:
+    x = tf_fn(slice_shape, **kwargs)
+    x = self.LaidOutTensor([x])
+    return x
+
 
   def export_to_tf_tensor(self, x, laid_out_x):
     """Turn a Tensor into a tf.Tensor.


### PR DESCRIPTION
This PR should solve the issue #3 and also improves on the PR #5 .

The main problem faced in on how to distribute the random generation depending on the defined tensor, mesh and distribution strategy.

The strategy taken in this pull request is to modify the corresponding seeds of each GPU so that they match the GPUs they need to match and are different to the GPUs they need to be.

The difficulty is that given the distribution strategy we might have some dimensions that are distributed and some others that are not. As a function of that the random numbers generated should have or have not the same seed.

The implementation is partially inspired by the function [slice](https://github.com/DifferentiableUniverseInitiative/mesh/blob/4d355c840fec8592e95597747c87b66e8fe4ae81/mesh_tensorflow/hvd_simd_mesh_impl.py#L542) and the way it looks for the starting points for each distributed tensor. All the processes should start with a common seed and then this seed will be modified depending the tensor, the mesh and the distribution strategy. 

The communication between the GPUs is minimised with this implementation. However, we still need to see how to define a random common seed for all the processes if it is not defined by the "user".

The script [mtf_random.py](https://github.com/DifferentiableUniverseInitiative/mesh/blob/tob_random/examples/mtf_random.py) allows to test the distribution of the random tensors.

